### PR TITLE
Update macOS Build Configuration for Universal Binary (Intel & ARM)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,121 +10,145 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.1.7
 
-    - name: Create Build Environment
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y build-essential libgl1-mesa-dev libglvnd-dev cmake qt6-base-dev
-        mkdir build
-  
-    - name: Configure CMake
-      working-directory: ${{github.workspace}}/build
-      shell: bash
-      run: |
-        cmake -DCMAKE_BUILD_TYPE=Release ..
+      - name: Create Build Environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libgl1-mesa-dev libglvnd-dev cmake qt6-base-dev
+          mkdir build
 
-    - name: Build
-      working-directory: ${{github.workspace}}/build
-      shell: bash
-      run: |
-        make -j4
-        
-    - name: Archive Artifact
-      working-directory: ${{github.workspace}}/build
-      shell: bash
-      run: |
-        tar -czvf NDSFactory-${{ github.ref_name }}-Linux-x64.tar.gz NDSFactory ../README.md ../LICENSE
-    
-    - name: Release on GitHub
-      uses: softprops/action-gh-release@v2.0.8
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: "build/NDSFactory-${{ github.ref_name }}-Linux-x64.tar.gz"
-        
+      - name: Configure CMake
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=Release ..
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        run: |
+          make -j4
+
+      - name: Archive Artifact
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        run: |
+          tar -czvf NDSFactory-${{ github.ref_name }}-Linux-x64.tar.gz NDSFactory ../README.md ../LICENSE
+
+      - name: Release on GitHub
+        uses: softprops/action-gh-release@v2.0.8
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: "build/NDSFactory-${{ github.ref_name }}-Linux-x64.tar.gz"
+
   build-macos:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4.1.7
-    
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v4
-      with:
-        version: '6.7.2'
-      
-    - name: Install CMake
-      uses: lukka/get-cmake@latest
+      - uses: actions/checkout@v4.1.7
 
-    - name: Create Build Environment
-      run: |
-        mkdir build
-        
-    - name: Configure CMake
-      working-directory: ${{github.workspace}}/build
-      shell: bash
-      run: |
-        cmake -DCMAKE_BUILD_TYPE=Release ..
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.7.2"
 
-    - name: Build
-      working-directory: ${{github.workspace}}/build
-      shell: bash
-      run: |
-        make -j4
-        macdeployqt NDSFactory.app
+      - name: Install CMake
+        uses: lukka/get-cmake@latest
 
-    - name: Archive Artifact
-      working-directory: ${{github.workspace}}/build
-      shell: bash
-      run: |
-        zip -r NDSFactory-${{ github.ref_name }}-macOS.zip NDSFactory.app ../README.md ../LICENSE
+      - name: Create Build Environment
+        run: |
+          mkdir -p build/x86_64 build/arm64 build/universal
 
-    - name: Release on GitHub
-      uses: softprops/action-gh-release@v2.0.8
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: "build/NDSFactory-${{ github.ref_name }}-macOS.zip"
+      - name: Configure CMake (x86_64)
+        working-directory: ${{ github.workspace }}/build/x86_64
+        shell: bash
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=x86_64 ../..
+
+      - name: Configure CMake (arm64)
+        working-directory: ${{ github.workspace }}/build/arm64
+        shell: bash
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 ../..
+
+      - name: Build (x86_64)
+        working-directory: ${{ github.workspace }}/build/x86_64
+        shell: bash
+        run: |
+          make -j4
+
+      - name: Build (arm64)
+        working-directory: ${{ github.workspace }}/build/arm64
+        shell: bash
+        run: |
+          make -j4
+
+      - name: Create Universal Binary
+        working-directory: ${{ github.workspace }}/build
+        shell: bash
+        run: |
+          cp -R x86_64/NDSFactory.app universal/
+          lipo -create -output universal/NDSFactory.app/Contents/MacOS/NDSFactory x86_64/NDSFactory.app/Contents/MacOS/NDSFactory arm64/NDSFactory.app/Contents/MacOS/NDSFactory
+
+      - name: Deploy Qt Frameworks
+        working-directory: ${{ github.workspace }}/build/universal
+        shell: bash
+        run: |
+          macdeployqt NDSFactory.app -verbose=1 -dmg
+
+      - name: Archive Artifact
+        working-directory: ${{ github.workspace }}/build/universal
+        shell: bash
+        run: |
+          zip -r NDSFactory-${{ github.ref_name }}-macOS.zip NDSFactory.app ../README.md ../LICENSE
+
+      - name: Release on GitHub
+        uses: softprops/action-gh-release@v2.0.8
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: "build/universal/NDSFactory-${{ github.ref_name }}-macOS.zip"
 
   build-windows:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4.1.7
-    
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v4
-      with:
-        version: '6.7.2'
-      
-    - name: Install CMake
-      uses: lukka/get-cmake@latest
+      - uses: actions/checkout@v4.1.7
 
-    - name: Create Build Environment
-      run: |
-        mkdir build
-        
-    - name: Configure CMake
-      working-directory: ${{github.workspace}}/build
-      run: |
-        cmake ..
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.7.2"
 
-    - name: Build
-      working-directory: ${{github.workspace}}/build
-      run: |
-        cmake --build . -j4 --config Release
-        mkdir .\Release\prod
-        move .\Release\NDSFactory.exe .\Release\prod
-        windeployqt .\Release\prod\NDSFactory.exe
-        
-    - name: Archive Artifact
-      working-directory: ${{github.workspace}}/build/Release
-      run: |
-        xcopy ..\..\README.md .\prod
-        xcopy ..\..\LICENSE .\prod
-        powershell "Compress-Archive -Path .\prod\* -DestinationPath .\NDSFactory-${{ github.ref_name }}-Windows-x64.zip"
+      - name: Install CMake
+        uses: lukka/get-cmake@latest
 
-    - name: Release on GitHub
-      uses: softprops/action-gh-release@v2.0.8
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: "build/Release/NDSFactory-${{ github.ref_name }}-Windows-x64.zip"
+      - name: Create Build Environment
+        run: |
+          mkdir build
+
+      - name: Configure CMake
+        working-directory: ${{github.workspace}}/build
+        run: |
+          cmake ..
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build
+        run: |
+          cmake --build . -j4 --config Release
+          mkdir .\Release\prod
+          move .\Release\NDSFactory.exe .\Release\prod
+          windeployqt .\Release\prod\NDSFactory.exe
+
+      - name: Archive Artifact
+        working-directory: ${{github.workspace}}/build/Release
+        run: |
+          xcopy ..\..\README.md .\prod
+          xcopy ..\..\LICENSE .\prod
+          powershell "Compress-Archive -Path .\prod\* -DestinationPath .\NDSFactory-${{ github.ref_name }}-Windows-x64.zip"
+
+      - name: Release on GitHub
+        uses: softprops/action-gh-release@v2.0.8
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: "build/Release/NDSFactory-${{ github.ref_name }}-Windows-x64.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
         working-directory: ${{ github.workspace }}/build/universal
         shell: bash
         run: |
-          macdeployqt NDSFactory.app -verbose=1 -dmg
+          macdeployqt NDSFactory.app -verbose=1
 
       - name: Archive Artifact
         working-directory: ${{ github.workspace }}/build/universal


### PR DESCRIPTION
This PR updates the macOS build configuration to produce a Universal Binary, ensuring compatibility with both Intel (x86_64) and Apple Silicon (ARM64) processors.

# Changes
✅ Added separate CMake builds for x86_64 and arm64 architectures
✅ Merged binaries using lipo to create a Universal Binary
✅ Adjusted macdeployqt to package the universal app properly
✅ Updated GitHub Actions workflow to handle dual-architecture builds

# Impact
The resulting NDSFactory.app will now run natively on both Intel and Apple Silicon Macs.
Improves performance and compatibility without requiring Rosetta 2.
# Testing
- Built and verified on macOS
- Checked with lipo -info to confirm universal binary
- Tested application execution on both Intel **still need to be tested on Apple Silicon** 