### PR TITLE
Fix file dialog not opening on macOS 26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(FORMS
 # Platform-specific executable creation
 if(APPLE)
     set(MACOSX_BUNDLE_ICON_FILE ndsfactory.icns)
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER dev.lucadamico.ndsfactory)
     set(MACOS_ICNS "res/ndsfactory.icns")
     set_source_files_properties(${MACOS_ICNS} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
     add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${SOURCES} ${HEADERS} ${FORMS} ${MACOS_ICNS})


### PR DESCRIPTION
On macOS 26, native file dialogs will not open at all unless a bundle identifier is set in the application's Info.plist file.
https://forum.qt.io/topic/162825/qfiledialog-getopenfilename-fails-to-display-dialog-with-native-macos/5

Simply setting `MACOSX_BUNDLE_GUI_IDENTIFIER` in the CMake build script fixes the issue :P